### PR TITLE
Dynamic Pagination of Issues & Pull Requests

### DIFF
--- a/lazy_github/lib/github/issues.py
+++ b/lazy_github/lib/github/issues.py
@@ -4,6 +4,8 @@ from lazy_github.lib.constants import IssueOwnerFilter, IssueStateFilter
 from lazy_github.lib.context import LazyGithubContext, github_headers
 from lazy_github.models.github import Issue, IssueComment, PartialPullRequest, Repository
 
+DEFAULT_PAGE_SIZE = 30
+
 
 class UpdateIssuePayload(TypedDict):
     title: str | None
@@ -11,9 +13,11 @@ class UpdateIssuePayload(TypedDict):
     state: str | None
 
 
-async def list_issues(repo: Repository, state: IssueStateFilter, owner: IssueOwnerFilter) -> list[Issue]:
+async def list_issues(
+    repo: Repository, state: IssueStateFilter, owner: IssueOwnerFilter, page: int = 1, per_page: int = DEFAULT_PAGE_SIZE
+) -> list[Issue]:
     """Fetch issues (included pull requests) from the repo matching the state/owner filters"""
-    query_params = {"state": str(state).lower()}
+    query_params = {"state": str(state).lower(), "page": page, "per_page": per_page}
     if owner == IssueOwnerFilter.MINE:
         user = await LazyGithubContext.client.user()
         query_params["creator"] = user.login

--- a/lazy_github/ui/widgets/actions.py
+++ b/lazy_github/ui/widgets/actions.py
@@ -1,13 +1,14 @@
 from textual.app import ComposeResult
+from textual.widgets import DataTable
 
 from lazy_github.lib.messages import RepoSelected
-from lazy_github.ui.widgets.common import LazyGithubContainer, LazyGithubDataTable
+from lazy_github.ui.widgets.common import LazyGithubContainer
 
 
 class ActionsContainer(LazyGithubContainer):
     def compose(self) -> ComposeResult:
         self.border_title = "[4] Actions"
-        yield LazyGithubDataTable(id="actions_table")
+        yield DataTable(id="actions_table")
 
     async def on_repo_selected(self, message: RepoSelected) -> None:
         # TODO: Load the actions for the selected repo

--- a/lazy_github/ui/widgets/common.py
+++ b/lazy_github/ui/widgets/common.py
@@ -138,7 +138,7 @@ class LazilyLoadedDataTable(SearchableDataTable):
         if not self.load_function:
             return
 
-        initial_data = await self.load_function(self.current_batch, self.batch_size)
+        initial_data = await self.load_function(self.batch_size, self.current_batch)
         self.set_rows(initial_data)
 
         if len(initial_data) == 0:
@@ -149,6 +149,7 @@ class LazilyLoadedDataTable(SearchableDataTable):
 
     @work(exclusive=True)
     async def load_more_data(self, row_highlighted: DataTable.RowHighlighted) -> None:
+        # TODO: This should probably lock instead of relying on exclusive=True
         rows_remaining = len(self._rows_cache) - row_highlighted.cursor_row
         if not (self.can_load_more and self.load_function):
             return
@@ -156,7 +157,7 @@ class LazilyLoadedDataTable(SearchableDataTable):
         if rows_remaining > self.load_more_data_buffer:
             return
 
-        additional_data = await self.load_function(self.current_batch + 1, self.batch_size)
+        additional_data = await self.load_function(self.batch_size, self.current_batch + 1)
         self.current_batch += 1
         if len(additional_data) == 0:
             self.can_load_more = False

--- a/lazy_github/ui/widgets/issues.py
+++ b/lazy_github/ui/widgets/issues.py
@@ -1,22 +1,26 @@
-from typing import Dict
+from typing import Dict, Iterable
 
 from textual import on, work
 from textual.app import ComposeResult
 from textual.containers import ScrollableContainer, VerticalScroll
 from textual.coordinate import Coordinate
-from textual.widgets import Label, Markdown, Rule, TabPane
-from textual.widgets.data_table import CellDoesNotExist
+from textual.widgets import DataTable, Label, Markdown, Rule, TabPane
+from textual.widgets.data_table import CellDoesNotExist, CellType
 
 from lazy_github.lib.context import LazyGithubContext
-from lazy_github.lib.github.issues import get_comments
+from lazy_github.lib.github.issues import get_comments, list_issues
 from lazy_github.lib.messages import IssuesAndPullRequestsFetched, IssueSelected
 from lazy_github.lib.utils import link
-from lazy_github.models.github import Issue, IssueState
+from lazy_github.models.github import Issue, IssueState, PartialPullRequest
 from lazy_github.ui.screens.edit_issue import EditIssueModal
 from lazy_github.ui.screens.new_issue import NewIssueModal
 from lazy_github.ui.widgets.command_log import log_event
-from lazy_github.ui.widgets.common import LazyGithubContainer, LazyGithubDataTable, SearchableLazyGithubDataTable
+from lazy_github.ui.widgets.common import LazilyLoadedDataTable, LazyGithubContainer, SearchableDataTable
 from lazy_github.ui.widgets.conversations import IssueCommentContainer
+
+
+def issue_to_cell(issue: Issue) -> Iterable[CellType]:
+    return (issue.number, issue.state, issue.user.login, issue.title)
 
 
 class IssuesContainer(LazyGithubContainer):
@@ -32,21 +36,40 @@ class IssuesContainer(LazyGithubContainer):
 
     def compose(self) -> ComposeResult:
         self.border_title = "[3] Issues"
-        yield SearchableLazyGithubDataTable(
+        yield LazilyLoadedDataTable(
             id="searchable_issues_table",
             table_id="issues_table",
             search_input_id="issues_search",
             sort_key="number",
+            load_function=None,
+            batch_size=30,
             reverse_sort=True,
         )
 
-    @property
-    def searchable_table(self) -> SearchableLazyGithubDataTable:
-        return self.query_one("#searchable_issues_table", SearchableLazyGithubDataTable)
+    async def fetch_more_issues(self, batch_size: int, batch_to_fetch: int) -> Iterable[Iterable[CellType]]:
+        next_page = await list_issues(
+            LazyGithubContext.current_repo,
+            LazyGithubContext.config.issues.state_filter,
+            LazyGithubContext.config.issues.owner_filter,
+            page=batch_to_fetch,
+            per_page=batch_size,
+        )
+
+        log_event(f"Loading more issues page={batch_to_fetch}, per_page={batch_size}")
+        log_event([f"#{i.number} == {type(i)}" for i in next_page])
+
+        new_issues = [i for i in next_page if not isinstance(i, PartialPullRequest)]
+        self.issues.update({i.number: i for i in new_issues})
+
+        return [issue_to_cell(i) for i in new_issues]
 
     @property
-    def table(self) -> LazyGithubDataTable:
-        return self.query_one("#issues_table", LazyGithubDataTable)
+    def searchable_table(self) -> LazilyLoadedDataTable:
+        return self.query_one("#searchable_issues_table", LazilyLoadedDataTable)
+
+    @property
+    def table(self) -> DataTable:
+        return self.query_one("#issues_table", DataTable)
 
     def on_mount(self) -> None:
         self.table.cursor_type = "row"
@@ -68,7 +91,9 @@ class IssuesContainer(LazyGithubContainer):
         for issue in message.issues:
             self.issues[issue.number] = issue
             rows.append((issue.number, issue.state, issue.user.login, issue.title))
-        self.searchable_table.add_rows(rows)
+        self.searchable_table.set_rows(rows)
+        self.searchable_table.change_load_function(self.fetch_more_issues)
+        self.searchable_table.batch_size += 1
 
     async def get_selected_issue(self) -> Issue:
         pr_number_coord = Coordinate(self.table.cursor_row, self.number_column_index)
@@ -88,7 +113,7 @@ class IssuesContainer(LazyGithubContainer):
         else:
             self.notify("No repository currently selected", severity="error")
 
-    @on(LazyGithubDataTable.RowSelected, "#issues_table")
+    @on(DataTable.RowSelected, "#issues_table")
     async def issue_selected(self) -> None:
         issue = await self.get_selected_issue()
         log_event(f"Selected Issue: #{issue.number}")

--- a/lazy_github/ui/widgets/issues.py
+++ b/lazy_github/ui/widgets/issues.py
@@ -47,8 +47,13 @@ class IssuesContainer(LazyGithubContainer):
         )
 
     async def fetch_more_issues(self, batch_size: int, batch_to_fetch: int) -> list[tuple[str | int, ...]]:
+        from lazy_github.ui.widgets.command_log import log_event
+
         if not LazyGithubContext.current_repo:
+            log_event("Skipping fetching more")
             return []
+
+        log_event(f"Fetching more issues (batch={batch_to_fetch}, size={batch_size})")
 
         next_page = await list_issues(
             LazyGithubContext.current_repo,
@@ -58,8 +63,10 @@ class IssuesContainer(LazyGithubContainer):
             per_page=batch_size,
         )
 
+        log_event(f"Fetched {len(next_page)} THINGS")
         new_issues = [i for i in next_page if not isinstance(i, PartialPullRequest)]
         self.issues.update({i.number: i for i in new_issues})
+        log_event(f"Fetched {len(new_issues)} issues")
 
         return [issue_to_cell(i) for i in new_issues]
 
@@ -93,7 +100,8 @@ class IssuesContainer(LazyGithubContainer):
             rows.append((issue.number, issue.state, issue.user.login, issue.title))
         self.searchable_table.set_rows(rows)
         self.searchable_table.change_load_function(self.fetch_more_issues)
-        self.searchable_table.current_batch += 1
+        self.searchable_table.can_load_more = True
+        self.searchable_table.current_batch = 1
 
     async def get_selected_issue(self) -> Issue:
         pr_number_coord = Coordinate(self.table.cursor_row, self.number_column_index)

--- a/lazy_github/ui/widgets/issues.py
+++ b/lazy_github/ui/widgets/issues.py
@@ -47,13 +47,8 @@ class IssuesContainer(LazyGithubContainer):
         )
 
     async def fetch_more_issues(self, batch_size: int, batch_to_fetch: int) -> list[tuple[str | int, ...]]:
-        from lazy_github.ui.widgets.command_log import log_event
-
         if not LazyGithubContext.current_repo:
-            log_event("Skipping fetching more")
             return []
-
-        log_event(f"Fetching more issues (batch={batch_to_fetch}, size={batch_size})")
 
         next_page = await list_issues(
             LazyGithubContext.current_repo,
@@ -63,10 +58,8 @@ class IssuesContainer(LazyGithubContainer):
             per_page=batch_size,
         )
 
-        log_event(f"Fetched {len(next_page)} THINGS")
         new_issues = [i for i in next_page if not isinstance(i, PartialPullRequest)]
         self.issues.update({i.number: i for i in new_issues})
-        log_event(f"Fetched {len(new_issues)} issues")
 
         return [issue_to_cell(i) for i in new_issues]
 

--- a/lazy_github/ui/widgets/pull_requests.py
+++ b/lazy_github/ui/widgets/pull_requests.py
@@ -3,7 +3,7 @@ from textual import on, work
 from textual.app import ComposeResult
 from textual.containers import ScrollableContainer, VerticalScroll
 from textual.coordinate import Coordinate
-from textual.widgets import Label, Markdown, RichLog, Rule, TabPane
+from textual.widgets import DataTable, Label, Markdown, RichLog, Rule, TabPane
 
 from lazy_github.lib.github.issues import get_comments
 from lazy_github.lib.github.pull_requests import (
@@ -16,7 +16,7 @@ from lazy_github.lib.utils import bold, link, pluralize
 from lazy_github.models.github import FullPullRequest, PartialPullRequest
 from lazy_github.ui.screens.new_comment import NewCommentModal
 from lazy_github.ui.widgets.command_log import log_event
-from lazy_github.ui.widgets.common import LazyGithubContainer, LazyGithubDataTable, SearchableLazyGithubDataTable
+from lazy_github.ui.widgets.common import LazyGithubContainer, SearchableDataTable
 from lazy_github.ui.widgets.conversations import IssueCommentContainer, ReviewContainer
 
 
@@ -34,7 +34,7 @@ class PullRequestsContainer(LazyGithubContainer):
 
     def compose(self) -> ComposeResult:
         self.border_title = "[2] Pull Requests"
-        yield SearchableLazyGithubDataTable(
+        yield SearchableDataTable(
             id="searchable_prs",
             table_id="pull_requests_table",
             search_input_id="pr_search_query",
@@ -43,11 +43,11 @@ class PullRequestsContainer(LazyGithubContainer):
         )
 
     @property
-    def searchable_table(self) -> SearchableLazyGithubDataTable:
-        return self.query_one("#searchable_prs", SearchableLazyGithubDataTable)
+    def searchable_table(self) -> SearchableDataTable:
+        return self.query_one("#searchable_prs", SearchableDataTable)
 
     @property
-    def table(self) -> LazyGithubDataTable:
+    def table(self) -> DataTable:
         return self.searchable_table.table
 
     def on_mount(self) -> None:
@@ -70,14 +70,14 @@ class PullRequestsContainer(LazyGithubContainer):
         for pr in message.pull_requests:
             self.pull_requests[pr.number] = pr
             rows.append((pr.number, pr.state, pr.user.login, pr.title))
-        self.searchable_table.add_rows(rows)
+        self.searchable_table.set_rows(rows)
 
     async def get_selected_pr(self) -> PartialPullRequest:
         pr_number_coord = Coordinate(self.table.cursor_row, self.number_column_index)
         number = self.table.get_cell_at(pr_number_coord)
         return self.pull_requests[number]
 
-    @on(LazyGithubDataTable.RowSelected, "#pull_requests_table")
+    @on(DataTable.RowSelected, "#pull_requests_table")
     async def pr_selected(self) -> None:
         pr = await self.get_selected_pr()
         log_event(f"Selected PR: #{pr.number}")

--- a/lazy_github/ui/widgets/pull_requests.py
+++ b/lazy_github/ui/widgets/pull_requests.py
@@ -5,7 +5,8 @@ from textual.containers import ScrollableContainer, VerticalScroll
 from textual.coordinate import Coordinate
 from textual.widgets import DataTable, Label, Markdown, RichLog, Rule, TabPane
 
-from lazy_github.lib.github.issues import get_comments
+from lazy_github.lib.context import LazyGithubContext
+from lazy_github.lib.github.issues import get_comments, list_issues
 from lazy_github.lib.github.pull_requests import (
     get_diff,
     get_reviews,
@@ -16,8 +17,12 @@ from lazy_github.lib.utils import bold, link, pluralize
 from lazy_github.models.github import FullPullRequest, PartialPullRequest
 from lazy_github.ui.screens.new_comment import NewCommentModal
 from lazy_github.ui.widgets.command_log import log_event
-from lazy_github.ui.widgets.common import LazyGithubContainer, SearchableDataTable
+from lazy_github.ui.widgets.common import LazilyLoadedDataTable, LazyGithubContainer, SearchableDataTable
 from lazy_github.ui.widgets.conversations import IssueCommentContainer, ReviewContainer
+
+
+def pull_request_to_cell(pr: PartialPullRequest) -> tuple[str | int, ...]:
+    return (pr.number, str(pr.state), pr.user.login, pr.title)
 
 
 class PullRequestsContainer(LazyGithubContainer):
@@ -34,17 +39,36 @@ class PullRequestsContainer(LazyGithubContainer):
 
     def compose(self) -> ComposeResult:
         self.border_title = "[2] Pull Requests"
-        yield SearchableDataTable(
+        yield LazilyLoadedDataTable(
             id="searchable_prs",
             table_id="pull_requests_table",
             search_input_id="pr_search_query",
             sort_key="number",
+            load_function=None,
+            batch_size=30,
             reverse_sort=True,
         )
 
+    async def fetch_more_pull_requests(self, batch_size: int, batch_to_fetch: int) -> list[tuple[str | int, ...]]:
+        if not LazyGithubContext.current_repo:
+            return []
+
+        next_page = await list_issues(
+            LazyGithubContext.current_repo,
+            LazyGithubContext.config.pull_requests.state_filter,
+            LazyGithubContext.config.pull_requests.owner_filter,
+            page=batch_to_fetch,
+            per_page=batch_size,
+        )
+
+        new_pulls = [i for i in next_page if isinstance(i, PartialPullRequest)]
+        self.pull_requests.update({i.number: i for i in new_pulls})
+
+        return [pull_request_to_cell(i) for i in new_pulls]
+
     @property
-    def searchable_table(self) -> SearchableDataTable:
-        return self.query_one("#searchable_prs", SearchableDataTable)
+    def searchable_table(self) -> LazilyLoadedDataTable:
+        return self.query_one("#searchable_prs", LazilyLoadedDataTable)
 
     @property
     def table(self) -> DataTable:
@@ -69,8 +93,11 @@ class PullRequestsContainer(LazyGithubContainer):
         rows = []
         for pr in message.pull_requests:
             self.pull_requests[pr.number] = pr
-            rows.append((pr.number, pr.state, pr.user.login, pr.title))
+            rows.append(pull_request_to_cell(pr))
         self.searchable_table.set_rows(rows)
+        self.searchable_table.change_load_function(self.fetch_more_pull_requests)
+        self.searchable_table.can_load_more = True
+        self.searchable_table.current_batch = 1
 
     async def get_selected_pr(self) -> PartialPullRequest:
         pr_number_coord = Coordinate(self.table.cursor_row, self.number_column_index)

--- a/lazy_github/ui/widgets/pull_requests.py
+++ b/lazy_github/ui/widgets/pull_requests.py
@@ -17,7 +17,7 @@ from lazy_github.lib.utils import bold, link, pluralize
 from lazy_github.models.github import FullPullRequest, PartialPullRequest
 from lazy_github.ui.screens.new_comment import NewCommentModal
 from lazy_github.ui.widgets.command_log import log_event
-from lazy_github.ui.widgets.common import LazilyLoadedDataTable, LazyGithubContainer, SearchableDataTable
+from lazy_github.ui.widgets.common import LazilyLoadedDataTable, LazyGithubContainer
 from lazy_github.ui.widgets.conversations import IssueCommentContainer, ReviewContainer
 
 
@@ -62,7 +62,6 @@ class PullRequestsContainer(LazyGithubContainer):
         )
 
         new_pulls = [i for i in next_page if isinstance(i, PartialPullRequest)]
-        self.pull_requests.update({i.number: i for i in new_pulls})
 
         return [pull_request_to_cell(i) for i in new_pulls]
 

--- a/lazy_github/ui/widgets/repositories.py
+++ b/lazy_github/ui/widgets/repositories.py
@@ -3,6 +3,7 @@ from typing import Dict, Iterable
 from textual import on, work
 from textual.app import ComposeResult
 from textual.coordinate import Coordinate
+from textual.widgets import DataTable
 
 import lazy_github.lib.github.repositories as repos_api
 from lazy_github.lib.constants import IS_FAVORITED, favorite_string, private_string
@@ -10,7 +11,7 @@ from lazy_github.lib.context import LazyGithubContext
 from lazy_github.lib.messages import RepoSelected
 from lazy_github.models.github import Repository
 from lazy_github.ui.widgets.command_log import log_event
-from lazy_github.ui.widgets.common import LazyGithubContainer, LazyGithubDataTable, SearchableLazyGithubDataTable
+from lazy_github.ui.widgets.common import LazyGithubContainer, SearchableDataTable
 
 
 class ReposContainer(LazyGithubContainer):
@@ -29,7 +30,7 @@ class ReposContainer(LazyGithubContainer):
 
     def compose(self) -> ComposeResult:
         self.border_title = "[1] Repositories"
-        yield SearchableLazyGithubDataTable(
+        yield SearchableDataTable(
             id="searchable_repos_table",
             table_id="repos_table",
             search_input_id="repo_search",
@@ -37,11 +38,11 @@ class ReposContainer(LazyGithubContainer):
         )
 
     @property
-    def searchable_table(self) -> SearchableLazyGithubDataTable:
-        return self.query_one("#searchable_repos_table", SearchableLazyGithubDataTable)
+    def searchable_table(self) -> SearchableDataTable:
+        return self.query_one("#searchable_repos_table", SearchableDataTable)
 
     @property
-    def table(self) -> LazyGithubDataTable:
+    def table(self) -> DataTable:
         return self.searchable_table.table
 
     async def on_mount(self) -> None:
@@ -77,7 +78,7 @@ class ReposContainer(LazyGithubContainer):
             private = private_string(repo.private)
             rows.append([favorited, repo.owner.login, repo.name, private])
             self.repos[repo.full_name] = repo
-        self.searchable_table.add_rows(rows)
+        self.searchable_table.set_rows(rows)
 
         # If the current user's directory is a git repo and they don't already have a git repo selected, try and mark
         # that repo as the current repo
@@ -108,7 +109,7 @@ class ReposContainer(LazyGithubContainer):
         self.table.update_cell_at(favorite_coord, favorite_string(updated_favorited))
         self.table.sort()
 
-    @on(LazyGithubDataTable.RowSelected, "#repos_table")
+    @on(DataTable.RowSelected, "#repos_table")
     async def repo_selected(self):
         # Bubble a message up indicating that a repo was selected
         repo = await self.get_selected_repo()


### PR DESCRIPTION
## What's changing?

This refactors the data table implementations to add support for a lazily loaded data table implementation. As implemented, if the user scrolls within 5 rows of the bottom of the table, it will trigger an attempt to load more data from the specified load function. If no data is received from that function, then it will set a flag indicating that no additional data can be loaded.

## Why is it changing?

This allows users to browse PRs and Issues on a larger repo without hard limits on the record count.