### PR TITLE
Fix issues with current notification command line interface

### DIFF
--- a/lazy_github/lib/github_cli.py
+++ b/lazy_github/lib/github_cli.py
@@ -1,5 +1,8 @@
 import json
 import subprocess
+import time
+from asyncio import sleep
+from dataclasses import dataclass
 
 from lazy_github.lib.logging import lg
 from lazy_github.models.github import Notification
@@ -7,37 +10,47 @@ from lazy_github.models.github import Notification
 NOTIFICATIONS_PAGE_COUNT = 30
 
 
-def _run_gh_cli_command(command: list[str]) -> subprocess.CompletedProcess[str]:
+@dataclass
+class _FinishedCommand:
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+async def _run_gh_cli_command(command: list[str]) -> _FinishedCommand:
     """Simple wrapper around running a Github CLI command"""
     full_command = ["gh"] + command
-    return subprocess.run(full_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    proc = subprocess.Popen(full_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    while True:
+        if proc.poll() is not None:
+            raw_stdout, raw_stderr = proc.communicate()
+            return _FinishedCommand(proc.returncode, raw_stdout.decode(), raw_stderr.decode())
+        else:
+            await sleep(0.3)
 
 
 async def is_logged_in() -> bool:
     """Checks to see if the user is currently logged into the GitHub CLI"""
     try:
-        result = _run_gh_cli_command(["auth", "status"])
+        result = await _run_gh_cli_command(["auth", "status"])
         return result.returncode == 0
     except Exception:
-        lg.exception("Something is fucked")
+        lg.exception("Error checking if github CLI is authenticated")
         return False
 
 
 async def fetch_notifications(all: bool) -> list[Notification]:
     """Fetches notifications on GitHub. If all=True, then previously read notifications will also be returned"""
-    result = _run_gh_cli_command(["api", f"/notifications?all={str(all).lower()}"])
+    result = await _run_gh_cli_command(["api", f"/notifications?all={str(all).lower()}"])
     notifications: list[Notification] = []
-    lg.debug(result.stdout)
-    lg.debug(result.stderr)
     if result.stdout:
-        lg.debug(f"Stdout is {result.stdout}")
-        parsed = json.loads(result.stdout.decode())
+        parsed = json.loads(result.stdout)
         notifications = [Notification(**n) for n in parsed]
     return notifications
 
 
 async def mark_notification_as_read(notification: Notification) -> None:
-    _run_gh_cli_command(["--method", "PATCH", "api", f"/notifications/threads/{notification.id}"])
+    await _run_gh_cli_command(["--method", "PATCH", "api", f"/notifications/threads/{notification.id}"])
 
 
 async def unread_notification_count() -> int:

--- a/lazy_github/lib/github_cli.py
+++ b/lazy_github/lib/github_cli.py
@@ -1,6 +1,5 @@
 import json
 import subprocess
-import time
 from asyncio import sleep
 from dataclasses import dataclass
 
@@ -22,7 +21,7 @@ async def _run_gh_cli_command(command: list[str]) -> _FinishedCommand:
     full_command = ["gh"] + command
     proc = subprocess.Popen(full_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     while True:
-        if proc.poll() is not None:
+        if proc.poll() is None:
             raw_stdout, raw_stderr = proc.communicate()
             return _FinishedCommand(proc.returncode, raw_stdout.decode(), raw_stderr.decode())
         else:

--- a/lazy_github/lib/github_cli.py
+++ b/lazy_github/lib/github_cli.py
@@ -1,42 +1,43 @@
-import asyncio
 import json
-from asyncio.subprocess import PIPE, Process
+import subprocess
 
+from lazy_github.lib.logging import lg
 from lazy_github.models.github import Notification
 
 NOTIFICATIONS_PAGE_COUNT = 30
 
 
-async def _run_gh_cli_command(command: str) -> Process:
+def _run_gh_cli_command(command: list[str]) -> subprocess.CompletedProcess[str]:
     """Simple wrapper around running a Github CLI command"""
-    return await asyncio.create_subprocess_shell(f"gh {command}", stdout=PIPE, stderr=PIPE)
+    full_command = ["gh"] + command
+    return subprocess.run(full_command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
 
 async def is_logged_in() -> bool:
     """Checks to see if the user is currently logged into the GitHub CLI"""
     try:
-        result = await _run_gh_cli_command("auth status")
-        await result.wait()
+        result = _run_gh_cli_command(["auth", "status"])
         return result.returncode == 0
     except Exception:
+        lg.exception("Something is fucked")
         return False
 
 
 async def fetch_notifications(all: bool) -> list[Notification]:
     """Fetches notifications on GitHub. If all=True, then previously read notifications will also be returned"""
-    result = await _run_gh_cli_command(f'api "/notifications?all={str(all).lower()}"')
-    await result.wait()
+    result = _run_gh_cli_command(["api", f"/notifications?all={str(all).lower()}"])
     notifications: list[Notification] = []
+    lg.debug(result.stdout)
+    lg.debug(result.stderr)
     if result.stdout:
-        stdout = await result.stdout.read()
-        parsed = json.loads(stdout.decode())
+        lg.debug(f"Stdout is {result.stdout}")
+        parsed = json.loads(result.stdout.decode())
         notifications = [Notification(**n) for n in parsed]
     return notifications
 
 
 async def mark_notification_as_read(notification: Notification) -> None:
-    result = await _run_gh_cli_command(f"--method PATCH api /notifications/threads/{notification.id}")
-    await result.wait()
+    _run_gh_cli_command(["--method", "PATCH", "api", f"/notifications/threads/{notification.id}"])
 
 
 async def unread_notification_count() -> int:

--- a/lazy_github/ui/screens/notifications.py
+++ b/lazy_github/ui/screens/notifications.py
@@ -117,14 +117,10 @@ class NotificationsContainer(Container):
 
     @work
     async def load_notifications(self) -> None:
-        lg.debug("Fetching notifications")
         notifications = await fetch_notifications(True)
-        lg.debug("Fetched notifications")
 
         unread_count = 0
-        total_count = 0
         for notification in notifications:
-            total_count += 1
             if notification.unread:
                 unread_count += 1
                 self.unread_tab.add_notification(notification)

--- a/lazy_github/ui/screens/notifications.py
+++ b/lazy_github/ui/screens/notifications.py
@@ -6,7 +6,6 @@ from textual.message import Message
 from textual.screen import ModalScreen
 from textual.widgets import Markdown, TabbedContent, TabPane
 
-from lazy_github.lib.logging import lg
 from lazy_github.lib.bindings import LazyGithubBindings
 from lazy_github.lib.constants import BULLET_POINT, CHECKMARK
 from lazy_github.lib.github_cli import fetch_notifications, mark_notification_as_read

--- a/lazy_github/ui/screens/notifications.py
+++ b/lazy_github/ui/screens/notifications.py
@@ -48,7 +48,7 @@ class _NotificationsTableTabPane(TabPane):
         )
 
     def on_mount(self) -> None:
-        # self.searchable_table.loading = True
+        self.searchable_table.loading = True
         self.searchable_table.table.cursor_type = "row"
         self.searchable_table.table.add_column("Updated At", key="updated_at")
         self.searchable_table.table.add_column("Subject", key="subject")
@@ -131,10 +131,8 @@ class NotificationsContainer(Container):
             else:
                 self.read_tab.add_notification(notification)
 
-        lg.info(f"Loaded {total_count} notifications")
-
-        # self.unread_tab.searchable_table.loading = False
-        # self.read_tab.searchable_table.loading = False
+        self.unread_tab.searchable_table.loading = False
+        self.read_tab.searchable_table.loading = False
 
         if unread_count:
             self.action_view_unread()
@@ -142,9 +140,6 @@ class NotificationsContainer(Container):
             self.action_view_read()
 
     def on_mount(self) -> None:
-        # self.read_tab.searchable_table.loading = True
-        # self.unread_tab.searchable_table.loading = True
-
         self.load_notifications()
 
 


### PR DESCRIPTION
The current way that CLI commands are issued for checking notifications can cause the process to hang indefinitely. I've updated these to work via a more standard subprocess mechanism, which has been more reliable in testing