### PR TITLE
Add a workflow for looking up a repo by name

### DIFF
--- a/lazy_github/lib/bindings.py
+++ b/lazy_github/lib/bindings.py
@@ -20,6 +20,7 @@ class LazyGithubBindings:
 
     # Repository actions
     TOGGLE_FAVORITE_REPO = Binding("ctrl+f", "toggle_favorite_repo", "Toggle Favorite", id="repositories.favorite")
+    LOOKUP_REPOSITORY = Binding("O", "lookup_repository", "Lookup Repository", id="repositories.lookup")
 
     # Common widget bindings
     SELECT_ENTRY = Binding("enter,space", "select_cursor", "Select table entry", id="common.table.select", show=False)

--- a/lazy_github/lib/config.py
+++ b/lazy_github/lib/config.py
@@ -51,6 +51,22 @@ class BindingsSettings(BaseModel):
 class RepositorySettings(BaseModel):
     """Repository-specific settings"""
 
+    @field_serializer("additional_repos_to_track", "favorites")
+    @classmethod
+    def serialize_string_list(cls, string_list: str | list[str]) -> list[str]:
+        if isinstance(string_list, list):
+            return string_list
+        elif isinstance(string_list, str):
+            return [s.strip() for s in string_list.split(",") if s.strip()]
+
+    @field_validator("additional_repos_to_track", "favorites", mode="before")
+    @classmethod
+    def parse_string_list(cls, v) -> list[str]:
+        if isinstance(v, str):
+            return [s.strip() for s in v.split(",") if s.strip()]
+        return v
+
+    additional_repos_to_track: list[str] = []
     favorites: list[str] = []
 
 

--- a/lazy_github/lib/github/repositories.py
+++ b/lazy_github/lib/github/repositories.py
@@ -1,6 +1,8 @@
 from functools import partial
 from typing import Literal
 
+from httpx import HTTPError
+
 from lazy_github.lib.context import LazyGithubContext, github_headers
 from lazy_github.models.github import Repository
 
@@ -53,3 +55,13 @@ async def _list(
 list_all = partial(_list, repo_types="all")
 list_owned = partial(_list, repo_types="owner")
 list_member_of = partial(_list, repo_types="member")
+
+
+async def get_repository_by_name(full_name: str) -> Repository | None:
+    """Looks up a repository by full name (owner/name)"""
+    try:
+        response = await LazyGithubContext.client.get(f"/repos/{full_name}", headers=github_headers())
+        response.raise_for_status()
+        return Repository(**response.json())
+    except HTTPError:
+        return None

--- a/lazy_github/ui/screens/lookup_repository.py
+++ b/lazy_github/ui/screens/lookup_repository.py
@@ -1,0 +1,100 @@
+from textual import on
+from textual.app import ComposeResult
+from textual.containers import Container, Horizontal
+from textual.screen import ModalScreen
+from textual.validation import Regex
+from textual.widgets import Button, Input, Label, Markdown, Rule, Switch
+
+from lazy_github.lib.bindings import LazyGithubBindings
+from lazy_github.lib.context import LazyGithubContext
+from lazy_github.lib.github.repositories import get_repository_by_name
+from lazy_github.models.github import Repository
+from lazy_github.ui.widgets.common import LazyGithubFooter
+
+
+class LookupRepositoryButtons(Horizontal):
+    DEFAULT_CSS = """
+    LookupRepositoryButtons {
+        align: center middle;
+        height: auto;
+        width: 100%;
+    }
+    Button {
+        margin: 1;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        yield Button("Open", id="lookup", variant="success")
+        yield Button("Cancel", id="cancel", variant="error")
+
+
+class LookupRepositoryContainer(Container):
+    DEFAULT_CSS = """
+    LookupRepositoryContainer {
+        align: center middle;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        yield Markdown("# Search for a repository by name:")
+        yield Label("[bold]Repository (owner/name):[/bold]")
+        yield Input(
+            id="repo_to_lookup",
+            placeholder="Repository name",
+            validators=Regex(r"^[^/]+/[^/]+$"),
+        )
+        yield Rule()
+        yield Label("Continue tracking this repo?")
+        yield Switch(id="continue_tracking")
+        yield Rule()
+        yield LookupRepositoryButtons()
+
+
+class LookupRepositoryModal(ModalScreen[Repository | None]):
+    DEFAULT_CSS = """
+    LookupRepositoryModal {
+        height: 80%;
+    }
+
+    LookupRepositoryContainer {
+        dock: top;
+        width: 60;
+        max-height: 25;
+        border: thick $background 80%;
+        background: $surface-lighten-3;
+    }
+    """
+
+    BINDINGS = [LazyGithubBindings.SUBMIT_DIALOG, LazyGithubBindings.CLOSE_DIALOG]
+
+    def compose(self) -> ComposeResult:
+        yield LookupRepositoryContainer()
+        yield LazyGithubFooter()
+
+    def _continue_tracking_repo(self, repo_name: str) -> None:
+        if repo_name not in LazyGithubContext.config.repositories.additional_repos_to_track:
+            with LazyGithubContext.config.to_edit() as config:
+                # If we haven't tracked this repo already, we will do so
+                config.repositories.additional_repos_to_track.append(repo_name)
+
+    @on(Button.Pressed, "#submit")
+    async def action_submit(self) -> None:
+        repo_input = self.query_one("#repo_to_lookup", Input)
+        continue_tracking_input = self.query_one("#continue_tracking", Switch)
+        if repo_input.is_valid:
+            repo_name = repo_input.value
+            if continue_tracking_input.value:
+                self._continue_tracking_repo(repo_name)
+
+            # Load the repo from from the Github API and return it to the caller
+            if repo := await get_repository_by_name(repo_input.value):
+                self.dismiss(repo)
+            else:
+                self.notify("Could not find repo!", title="Validation Error", severity="error")
+        else:
+            self.notify("You must enter a repo name!", title="Validation Error", severity="error")
+
+    @on(Button.Pressed, "#cancel")
+    async def action_close(self) -> None:
+        self.dismiss(None)

--- a/lazy_github/ui/screens/settings.py
+++ b/lazy_github/ui/screens/settings.py
@@ -233,9 +233,6 @@ class SettingsContainer(Container):
             for field, value in LazyGithubContext.config:
                 if field == "bindings":
                     yield BindingsSettingsSection()
-                # elif field == "repositories":
-                # These settings aren't manually adjusted
-                # continue
                 else:
                     new_section = SettingsSection(field, value)
                     self.settings_sections.append(new_section)

--- a/lazy_github/ui/screens/settings.py
+++ b/lazy_github/ui/screens/settings.py
@@ -49,10 +49,6 @@ class FieldSetting(Container):
     Input {
         width: 70;
     }
-
-    TextArea {
-        width: 70;
-    }
     """
 
     def _field_to_widget(self) -> Widget:

--- a/lazy_github/ui/screens/trigger_workflow.py
+++ b/lazy_github/ui/screens/trigger_workflow.py
@@ -43,7 +43,7 @@ class TriggerWorkflowContainer(Container):
         self.workflow = workflow
 
     def compose(self) -> ComposeResult:
-        assert LazyGithubContext.current_repo is not None, "Unexpectedly missing current repo in new PR modal"
+        assert LazyGithubContext.current_repo is not None, "Unexpectedly missing current repo in trigger workflow modal"
         yield Markdown(f"# Triggering workflow: {self.workflow.name}")
         yield Label("[bold]Branch[/bold]")
         yield Input(


### PR DESCRIPTION
## What's changing?

This adds a new repository lookup flow, giving users the ability to track and participate in repositories that aren't directly associated with your account. Alongside the new flow, there are also settings which allow these repos to be automatically loaded on startup and I've updated the repo settings to allow for favorite repos and the additionally tracks repos to be edited via the settings flow.

## Screenshots

**Looking up a repo:**
<img width="1293" alt="lookup_repo" src="https://github.com/user-attachments/assets/e3ed1933-5031-4a6d-8f71-2cf165c9c8e6">

**Viewing the cpython repo in LazyGithub**
<img width="1289" alt="viewing_cpython" src="https://github.com/user-attachments/assets/5e8fcd82-128f-4851-9d1c-f289f9cbe5fc">

**New repo management in the settings**
<img width="1291" alt="repo_settings" src="https://github.com/user-attachments/assets/a4ff9177-caa9-4300-baaa-af88f6b0bd39">
