### PR TITLE
Add link navigation, user details modal, and repo info pane

### DIFF
--- a/lazy_github/lib/bindings.py
+++ b/lazy_github/lib/bindings.py
@@ -77,6 +77,13 @@ class LazyGithubBindings:
         tooltip="Mark/unmark a repository as favorited, which are displayed at the top of the repos table",
     )
     LOOKUP_REPOSITORY = Binding("O", "lookup_repository", "Lookup Repository", id="repositories.lookup")
+    VIEW_USER_PROFILE = Binding(
+        "u",
+        "view_user_profile",
+        "View User",
+        id="user.view_profile",
+        tooltip="Open the GitHub profile for the author/owner of the highlighted row",
+    )
 
     # Common widget bindings
     SELECT_ENTRY = Binding("enter,space", "select_cursor", "Select table entry", id="common.table.select", show=False)

--- a/lazy_github/lib/bindings.py
+++ b/lazy_github/lib/bindings.py
@@ -182,6 +182,13 @@ class LazyGithubBindings:
     FOLLOW_LINK = Binding(
         "f", "follow_link", "Follow link", id="link.follow", tooltip="Show hints on visible links and pick one"
     )
+    FOLLOW_LINK_EXTERNAL = Binding(
+        "F",
+        "follow_link_external",
+        "Follow link (browser)",
+        id="link.follow_external",
+        tooltip="Show hints on visible links and open the pick in the system browser",
+    )
 
     # Focusing different UI elements
     FOCUS_REPOSITORY_TABLE = Binding(

--- a/lazy_github/lib/bindings.py
+++ b/lazy_github/lib/bindings.py
@@ -178,6 +178,11 @@ class LazyGithubBindings:
     # Paste link modal
     OPEN_PASTE_LINK_MODAL = Binding("ctrl+v", "open_link_paste_modal", "Paste link", id="link.paste")
 
+    # Hint-mode link follower
+    FOLLOW_LINK = Binding(
+        "f", "follow_link", "Follow link", id="link.follow", tooltip="Show hints on visible links and pick one"
+    )
+
     # Focusing different UI elements
     FOCUS_REPOSITORY_TABLE = Binding(
         "1",

--- a/lazy_github/lib/github/references.py
+++ b/lazy_github/lib/github/references.py
@@ -1,0 +1,68 @@
+"""Expand GitHub-flavored issue/PR references in Markdown bodies into real links.
+
+GitHub auto-links references like `#123`, `owner/repo#123`, and
+`https://github.com/owner/repo/pull/123` in rendered issue/PR/comment bodies.
+The raw Markdown source does not contain those links, so the Textual Markdown
+widget never sees them as clickable. We pre-process the body to replace bare
+references with proper Markdown links so the LinkClicked handler can intercept.
+"""
+
+import re
+
+from lazy_github.models.github import Repository
+
+# Matches `#123` and `owner/repo#123`. The owner/repo prefix is optional.
+# Negative lookbehind on `\w`, `/`, `&`, and `#` keeps us from matching
+# inside identifiers, paths, HTML entities, or `##headings`.
+_REFERENCE_RE = re.compile(
+    r"(?<![\w/&#])"
+    r"(?:(?P<owner>[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)/(?P<repo>[A-Za-z0-9._-]+))?"
+    r"#(?P<number>\d+)\b"
+)
+
+_FENCE_RE = re.compile(r"^\s*(```|~~~)")
+
+
+def _expand_segment(segment: str, owner: str, repo: str) -> str:
+    def repl(match: re.Match[str]) -> str:
+        ref_owner = match.group("owner") or owner
+        ref_repo = match.group("repo") or repo
+        number = match.group("number")
+        url = f"https://github.com/{ref_owner}/{ref_repo}/issues/{number}"
+        text = match.group(0)
+        return f"[{text}]({url})"
+
+    return _REFERENCE_RE.sub(repl, segment)
+
+
+def expand_issue_references(body: str | None, repo: Repository) -> str:
+    """Rewrite `#N` and `owner/repo#N` references into Markdown links.
+
+    Skips fenced code blocks and inline backtick spans so we don't munge code.
+    """
+    if not body:
+        return body or ""
+
+    owner, _, repo_name = repo.full_name.partition("/")
+    if not owner or not repo_name:
+        return body
+
+    out_lines: list[str] = []
+    in_fence = False
+    for line in body.splitlines(keepends=True):
+        if _FENCE_RE.match(line):
+            in_fence = not in_fence
+            out_lines.append(line)
+            continue
+        if in_fence:
+            out_lines.append(line)
+            continue
+
+        # Split on inline backtick spans, transforming only the non-code parts.
+        parts = re.split(r"(`+[^`\n]*`+)", line)
+        for i, part in enumerate(parts):
+            if i % 2 == 0:
+                parts[i] = _expand_segment(part, owner, repo_name)
+        out_lines.append("".join(parts))
+
+    return "".join(out_lines)

--- a/lazy_github/lib/github/references.py
+++ b/lazy_github/lib/github/references.py
@@ -1,10 +1,11 @@
-"""Expand GitHub-flavored issue/PR references in Markdown bodies into real links.
+"""Expand GitHub-flavored references in Markdown bodies into real links.
 
-GitHub auto-links references like `#123`, `owner/repo#123`, and
-`https://github.com/owner/repo/pull/123` in rendered issue/PR/comment bodies.
-The raw Markdown source does not contain those links, so the Textual Markdown
-widget never sees them as clickable. We pre-process the body to replace bare
-references with proper Markdown links so the LinkClicked handler can intercept.
+GitHub auto-links references like `#123`, `owner/repo#123`, and `@username`
+in rendered issue/PR/comment bodies. The raw Markdown source does not contain
+those links, so the Textual Markdown widget never sees them as clickable. We
+pre-process the body to replace bare references with proper Markdown links so
+the LinkClicked handler can intercept and route them through the in-app
+resolver.
 """
 
 import re
@@ -20,11 +21,19 @@ _REFERENCE_RE = re.compile(
     r"#(?P<number>\d+)\b"
 )
 
+# Matches `@username`. Negative lookbehind on `\w`, `@`, and `/` keeps us
+# from matching email addresses (`user@example.com`), `@@chains`, or paths.
+_MENTION_RE = re.compile(
+    r"(?<![\w@/])"
+    r"@(?P<username>[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)"
+    r"\b"
+)
+
 _FENCE_RE = re.compile(r"^\s*(```|~~~)")
 
 
 def _expand_segment(segment: str, owner: str, repo: str) -> str:
-    def repl(match: re.Match[str]) -> str:
+    def issue_repl(match: re.Match[str]) -> str:
         ref_owner = match.group("owner") or owner
         ref_repo = match.group("repo") or repo
         number = match.group("number")
@@ -32,11 +41,17 @@ def _expand_segment(segment: str, owner: str, repo: str) -> str:
         text = match.group(0)
         return f"[{text}]({url})"
 
-    return _REFERENCE_RE.sub(repl, segment)
+    def mention_repl(match: re.Match[str]) -> str:
+        username = match.group("username")
+        return f"[@{username}](https://github.com/{username})"
+
+    segment = _MENTION_RE.sub(mention_repl, segment)
+    segment = _REFERENCE_RE.sub(issue_repl, segment)
+    return segment
 
 
-def expand_issue_references(body: str | None, repo: Repository) -> str:
-    """Rewrite `#N` and `owner/repo#N` references into Markdown links.
+def expand_github_references(body: str | None, repo: Repository) -> str:
+    """Rewrite `#N`, `owner/repo#N`, and `@username` references into Markdown links.
 
     Skips fenced code blocks and inline backtick spans so we don't munge code.
     """

--- a/lazy_github/lib/github/repositories.py
+++ b/lazy_github/lib/github/repositories.py
@@ -66,6 +66,25 @@ async def get_repository_by_name(full_name: str) -> Repository | None:
         return None
 
 
+async def list_repos_for_user(
+    username: str,
+    sort: RepositorySortKey = "updated",
+    direction: SortDirection = "desc",
+    per_page: int = 30,
+) -> list[Repository]:
+    """Lists the public repositories owned by a given user."""
+    headers = github_headers(cache_duration=LazyGithubContext.config.cache.list_repos_ttl)
+    query_params = {"sort": sort, "direction": direction, "per_page": per_page}
+    try:
+        response = await LazyGithubContext.client.get(
+            f"/users/{username}/repos", headers=headers, params=query_params
+        )
+        response.raise_for_status()
+    except GithubApiRequestFailed:
+        return []
+    return [Repository(**r) for r in response.json()]
+
+
 async def get_collaborators(full_name: str) -> list[str]:
     """Returns collaborators for the specified repo"""
     collaborators = []

--- a/lazy_github/lib/github/repositories.py
+++ b/lazy_github/lib/github/repositories.py
@@ -85,6 +85,19 @@ async def list_repos_for_user(
     return [Repository(**r) for r in response.json()]
 
 
+async def get_repo_readme(repo: Repository) -> str | None:
+    """Fetch a repo's README as raw Markdown, or None if there isn't one."""
+    try:
+        response = await LazyGithubContext.client.get(
+            f"/repos/{repo.full_name}/readme",
+            headers=github_headers(accept="application/vnd.github.raw"),
+        )
+        response.raise_for_status()
+    except GithubApiRequestFailed:
+        return None
+    return response.text
+
+
 async def get_collaborators(full_name: str) -> list[str]:
     """Returns collaborators for the specified repo"""
     collaborators = []

--- a/lazy_github/lib/github/users.py
+++ b/lazy_github/lib/github/users.py
@@ -1,7 +1,12 @@
 from lazy_github.lib.context import LazyGithubContext
-from lazy_github.models.github import User
+from lazy_github.models.github import FullUser, User
 
 
 async def get_user_by_username(username: str) -> User | None:
     response = await LazyGithubContext.client.get(f"/users/{username}")
     return User(**response.json()) if response.is_success() else None
+
+
+async def get_full_user_by_username(username: str) -> FullUser | None:
+    response = await LazyGithubContext.client.get(f"/users/{username}")
+    return FullUser(**response.json()) if response.is_success() else None

--- a/lazy_github/models/github.py
+++ b/lazy_github/models/github.py
@@ -23,6 +23,21 @@ class User(BaseModel):
         return self.id
 
 
+class FullUser(User):
+    bio: str | None = None
+    company: str | None = None
+    location: str | None = None
+    blog: str | None = None
+    email: str | None = None
+    twitter_username: str | None = None
+    public_repos: int = 0
+    public_gists: int = 0
+    followers: int = 0
+    following: int = 0
+    created_at: datetime | None = None
+    type: str | None = None
+
+
 class RepositoryPermission(BaseModel):
     admin: bool
     maintain: bool

--- a/lazy_github/ui/screens/link_paste.py
+++ b/lazy_github/ui/screens/link_paste.py
@@ -9,24 +9,99 @@ from textual.validation import ValidationResult, Validator
 from textual.widgets import Button, Input, Label, Markdown, Rule
 
 from lazy_github.lib.bindings import LazyGithubBindings
+from lazy_github.lib.context import LazyGithubContext, github_headers
 from lazy_github.lib.github.backends.protocol import GithubApiRequestFailed
-from lazy_github.lib.github.issues import get_issue_by_number
 from lazy_github.lib.github.pull_requests import get_full_pull_request
 from lazy_github.lib.github.repositories import get_repository_by_name
-from lazy_github.models.github import FullPullRequest, Issue, Repository
+from lazy_github.lib.github.users import get_full_user_by_username
+from lazy_github.models.github import FullPullRequest, FullUser, Issue, Repository
 from lazy_github.ui.widgets.common import LazyGithubFooter, ModalDialogButtons
 
 REPO_PATTERN_STRING = r"(https://)?[^\/]+\/(?P<owner>[^\/]+)\/(?P<repo>[^\/]+)"
 REPO_PATTERN = re.compile(REPO_PATTERN_STRING)
 ISSUE_PATTERN = re.compile(REPO_PATTERN_STRING + r"\/issues\/(?P<issue>\d+).*")
 PR_PATTERN = re.compile(REPO_PATTERN_STRING + r"\/pull\/(?P<pull_request>\d+).*")
+USER_PATTERN = re.compile(r"(https://)?github\.com\/(?P<login>[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)\/?$")
 
-PastedLinkSubject = Repository | FullPullRequest | Issue
+PastedLinkSubject = Repository | FullPullRequest | Issue | FullUser
+
+
+class UnknownGithubLink(Exception):
+    """Raised when a URL doesn't match any known GitHub link pattern."""
+
+
+async def _resolve_issue_or_pr(repo: Repository, number: int) -> PastedLinkSubject | None:
+    """Look up `#number` in `repo`, returning a FullPullRequest if it's actually a PR.
+
+    GitHub's `/issues/{n}` endpoint serves both issues and PRs and includes a
+    `pull_request` key when the number refers to a PR. We check for that and
+    redirect to the PR endpoint so the UI opens the right view.
+    """
+    url = f"/repos/{repo.owner.login}/{repo.name}/issues/{number}"
+    try:
+        response = await LazyGithubContext.client.get(url, headers=github_headers())
+        response.raise_for_status()
+    except GithubApiRequestFailed:
+        return None
+
+    payload = response.json()
+    if "pull_request" in payload:
+        try:
+            return await get_full_pull_request(repo, number)
+        except GithubApiRequestFailed:
+            return None
+    return Issue(**payload, repo=repo)
+
+
+async def resolve_github_url(link: str, *, accept_repo: bool = True) -> PastedLinkSubject | None:
+    """Resolve a GitHub URL to a Repository, FullPullRequest, Issue, or FullUser.
+
+    `accept_repo=False` causes plain repo URLs (no /pull/N or /issues/N suffix)
+    to raise UnknownGithubLink instead of resolving — useful for the in-document
+    click handler, where opening a bare repo URL in-app would be a surprising
+    full UI swap. The paste modal keeps the default behavior.
+
+    Raises UnknownGithubLink if the URL doesn't match a known pattern.
+    Returns None if the underlying API lookup fails.
+    """
+    if user_match := USER_PATTERN.match(link):
+        try:
+            return await get_full_user_by_username(user_match.group("login"))
+        except GithubApiRequestFailed:
+            return None
+
+    if pr_match := PR_PATTERN.match(link):
+        match = pr_match
+    elif issue_match := ISSUE_PATTERN.match(link):
+        match = issue_match
+    elif accept_repo and (repo_match := REPO_PATTERN.match(link)):
+        match = repo_match
+    else:
+        raise UnknownGithubLink(link)
+
+    groups = match.groupdict()
+    repo = await get_repository_by_name(f"{groups['owner']}/{groups['repo']}")
+    if not repo:
+        return None
+
+    if issue_number := groups.get("issue"):
+        return await _resolve_issue_or_pr(repo, int(issue_number))
+    if pr_number := groups.get("pull_request"):
+        try:
+            return await get_full_pull_request(repo, int(pr_number))
+        except GithubApiRequestFailed:
+            return None
+    return repo
 
 
 class GithubLinkValidator(Validator):
     def validate(self, value: str) -> ValidationResult:
-        if REPO_PATTERN.match(value) or ISSUE_PATTERN.match(value) or PR_PATTERN.match(value):
+        if (
+            REPO_PATTERN.match(value)
+            or ISSUE_PATTERN.match(value)
+            or PR_PATTERN.match(value)
+            or USER_PATTERN.match(value)
+        ):
             return self.success()
         else:
             return self.failure()
@@ -69,35 +144,22 @@ class PasteLinkModal(ModalScreen[PastedLinkSubject]):
         yield LazyGithubFooter()
 
     async def _parse_link_and_action(self, link: str) -> None:
-        match = PR_PATTERN.match(link) or ISSUE_PATTERN.match(link) or REPO_PATTERN.match(link)
-        if match is None:
-            return
         self.query_one("#submit", Button).disabled = True
         self.query_one("#cancel", Button).disabled = True
-
-        groups = match.groupdict()
-
-        repo = await get_repository_by_name(f"{groups['owner']}/{groups['repo']}")
-        if not repo:
-            self.notify("Could not find repository!", title="Unknown repo", severity="error")
-            return
-
-        if issue_number := groups.get("issue"):
+        try:
             try:
-                issue = await get_issue_by_number(repo, int(issue_number))
-                self.dismiss(issue)
-            except GithubApiRequestFailed:
-                self.notify("Could not find issue!", title="Unknown issue", severity="error")
-        elif pr_number := groups.get("pull_request"):
-            try:
-                pr = await get_full_pull_request(repo, int(pr_number))
-                self.dismiss(pr)
-            except GithubApiRequestFailed:
-                self.notify("Could not find pull request!", title="Unknown PR", severity="error")
-        else:
-            self.notify("Unknown link")
-        self.query_one("#submit", Button).disabled = False
-        self.query_one("#cancel", Button).disabled = False
+                subject = await resolve_github_url(link)
+            except UnknownGithubLink:
+                self.notify("Unknown link")
+                return
+
+            if subject is None:
+                self.notify("Could not resolve link!", title="GitHub lookup failed", severity="error")
+                return
+            self.dismiss(subject)
+        finally:
+            self.query_one("#submit", Button).disabled = False
+            self.query_one("#cancel", Button).disabled = False
 
     @on(Button.Pressed, "#submit")
     async def action_submit(self) -> None:

--- a/lazy_github/ui/screens/primary.py
+++ b/lazy_github/ui/screens/primary.py
@@ -65,6 +65,7 @@ from lazy_github.ui.widgets.pull_requests import (
     PullRequestsContainer,
 )
 from lazy_github.ui.widgets.repositories import ReposContainer
+from lazy_github.ui.widgets.repository_details import RepoOverviewTabPane
 from lazy_github.ui.widgets.workflow_run_details import (
     WorkflowRunJobsTabPane,
     WorkflowRunLogsTabPane,
@@ -313,6 +314,14 @@ class MainViewPane(Container):
 
     async def load_repository(self, repo: Repository) -> None:
         await self.selections.load_repository(repo)
+        await self.load_repository_details(repo)
+
+    async def load_repository_details(self, repo: Repository) -> None:
+        tabbed_content = self.query_one("#selection_detail_tabs", TabbedContent)
+        await tabbed_content.clear_panes()
+        await tabbed_content.add_pane(RepoOverviewTabPane(repo))
+        key = LazyGithubContext.get_key(LazyGithubBindings.FOCUS_DETAIL_TABS)
+        self.details.border_title = Content.from_markup(f"\\[{key}] {repo.full_name} Details")
 
     async def load_pull_request(self, pull_request: PartialPullRequest, focus_pr_details: bool = True) -> None:
         if isinstance(pull_request, FullPullRequest):
@@ -611,4 +620,4 @@ class LazyGithubMainScreen(Screen):
     async def handle_repo_selection(self, message: RepoSelected) -> None:
         self.set_currently_loaded_repo(message.repo)
         assert LazyGithubContext.current_repo == message.repo
-        await self.main_view_pane.selections.load_repository(message.repo)
+        await self.main_view_pane.load_repository(message.repo)

--- a/lazy_github/ui/screens/primary.py
+++ b/lazy_github/ui/screens/primary.py
@@ -57,6 +57,7 @@ from lazy_github.ui.widgets.command_log import CommandLogSection
 from lazy_github.ui.widgets.common import LazyGithubContainer, LazyGithubFooter
 from lazy_github.ui.widgets.info import LazyGithubInfoTabPane
 from lazy_github.ui.widgets.issues import IssueConversationTabPane, IssueOverviewTabPane, IssuesContainer
+from lazy_github.ui.widgets.link_hints import follow_link
 from lazy_github.ui.widgets.pull_requests import (
     PrConversationTabPane,
     PrDiffTabPane,
@@ -431,7 +432,11 @@ class MainScreenCommandProvider(Provider):
 
 
 class LazyGithubMainScreen(Screen):
-    BINDINGS = [LazyGithubBindings.OPEN_NOTIFICATIONS_MODAL, LazyGithubBindings.OPEN_PASTE_LINK_MODAL]
+    BINDINGS = [
+        LazyGithubBindings.OPEN_NOTIFICATIONS_MODAL,
+        LazyGithubBindings.OPEN_PASTE_LINK_MODAL,
+        LazyGithubBindings.FOLLOW_LINK,
+    ]
     COMMANDS = {MainScreenCommandProvider}
     notification_refresh_timer: Timer | None = None
 
@@ -496,6 +501,10 @@ class LazyGithubMainScreen(Screen):
         event.prevent_default()
         event.stop()
         self.action_open_gh_link(event.href)
+
+    @work
+    async def action_follow_link(self) -> None:
+        await follow_link(self)
 
     @work
     async def action_view_notifications(self) -> None:

--- a/lazy_github/ui/screens/primary.py
+++ b/lazy_github/ui/screens/primary.py
@@ -1,3 +1,4 @@
+import webbrowser
 from functools import partial
 from typing import NamedTuple
 
@@ -12,7 +13,7 @@ from textual.screen import Screen
 from textual.timer import Timer
 from textual.types import IgnoreReturnCallbackType
 from textual.widget import Widget
-from textual.widgets import DataTable, TabbedContent
+from textual.widgets import DataTable, Markdown, TabbedContent
 
 from lazy_github.lib.bindings import LazyGithubBindings
 from lazy_github.lib.constants import NOTIFICATION_REFRESH_INTERVAL
@@ -33,13 +34,25 @@ from lazy_github.lib.messages import (
     ReviewsAndCommentsLoaded,
     WorkflowRunSelected,
 )
-from lazy_github.models.github import FullPullRequest, Issue, PartialPullRequest, Repository, WorkflowRun
+from lazy_github.models.github import (
+    FullPullRequest,
+    FullUser,
+    Issue,
+    PartialPullRequest,
+    Repository,
+    WorkflowRun,
+)
 from lazy_github.ui.screens.create_or_edit_pull_request import CreateOrEditPullRequestModal
 from lazy_github.ui.screens.debug import DebugModal
-from lazy_github.ui.screens.link_paste import PasteLinkModal
+from lazy_github.ui.screens.link_paste import (
+    PasteLinkModal,
+    UnknownGithubLink,
+    resolve_github_url,
+)
 from lazy_github.ui.screens.new_issue import NewIssueModal
 from lazy_github.ui.screens.notifications import NotificationsModal
 from lazy_github.ui.screens.settings import SettingsModal
+from lazy_github.ui.screens.user_profile import open_user_profile
 from lazy_github.ui.widgets.command_log import CommandLogSection
 from lazy_github.ui.widgets.common import LazyGithubContainer, LazyGithubFooter
 from lazy_github.ui.widgets.info import LazyGithubInfoTabPane
@@ -436,24 +449,53 @@ class LazyGithubMainScreen(Screen):
         self.set_currently_loaded_repo(repo)
         await self.main_view_pane.load_repository(repo)
 
-    @work
-    async def action_open_link_paste_modal(self) -> None:
-        link_subject = await self.app.push_screen_wait(PasteLinkModal())
+    async def _open_link_subject(self, link_subject: object) -> None:
         match link_subject:
             case FullPullRequest():
                 await self.set_repository(link_subject.repo)
                 await self.main_view_pane.load_pull_request(link_subject)
                 self.notify("Opening pull request for link")
-                return
             case Issue():
                 await self.set_repository(link_subject.repo)
                 await self.main_view_pane.load_issue(link_subject)
                 self.notify("Opening issue for link")
-                return
             case Repository():
                 await self.set_repository(link_subject)
                 self.notify("Opening repository for link")
-                return
+            case FullUser():
+                selected_repo = await open_user_profile(self.app, link_subject.login)
+                if selected_repo is not None:
+                    await self.set_repository(selected_repo)
+
+    @work
+    async def action_open_link_paste_modal(self) -> None:
+        link_subject = await self.app.push_screen_wait(PasteLinkModal())
+        if link_subject is not None:
+            await self._open_link_subject(link_subject)
+
+    @work
+    async def action_open_gh_link(self, url: str) -> None:
+        """Try to open a GitHub URL inside the app; fall back to the system browser.
+
+        We intercept PR/issue URLs (load in-app) and plain user URLs (open the
+        user profile modal). Plain repo URLs and other paths (actions runs,
+        blobs, etc.) are more useful in the browser.
+        """
+        try:
+            subject = await resolve_github_url(url, accept_repo=False)
+        except UnknownGithubLink:
+            webbrowser.open(url)
+            return
+        if subject is None:
+            webbrowser.open(url)
+            return
+        await self._open_link_subject(subject)
+
+    @on(Markdown.LinkClicked)
+    def handle_markdown_link_clicked(self, event: Markdown.LinkClicked) -> None:
+        event.prevent_default()
+        event.stop()
+        self.action_open_gh_link(event.href)
 
     @work
     async def action_view_notifications(self) -> None:

--- a/lazy_github/ui/screens/primary.py
+++ b/lazy_github/ui/screens/primary.py
@@ -445,6 +445,7 @@ class LazyGithubMainScreen(Screen):
         LazyGithubBindings.OPEN_NOTIFICATIONS_MODAL,
         LazyGithubBindings.OPEN_PASTE_LINK_MODAL,
         LazyGithubBindings.FOLLOW_LINK,
+        LazyGithubBindings.FOLLOW_LINK_EXTERNAL,
     ]
     COMMANDS = {MainScreenCommandProvider}
     notification_refresh_timer: Timer | None = None
@@ -514,6 +515,10 @@ class LazyGithubMainScreen(Screen):
     @work
     async def action_follow_link(self) -> None:
         await follow_link(self)
+
+    @work
+    async def action_follow_link_external(self) -> None:
+        await follow_link(self, external=True)
 
     @work
     async def action_view_notifications(self) -> None:

--- a/lazy_github/ui/screens/user_profile.py
+++ b/lazy_github/ui/screens/user_profile.py
@@ -1,0 +1,198 @@
+import asyncio
+
+from textual import on
+from textual.app import ComposeResult
+from textual.containers import Container, ScrollableContainer
+from textual.content import Content
+from textual.coordinate import Coordinate
+from textual.screen import ModalScreen
+from textual.widgets import Label, Markdown, Rule
+
+from lazy_github.lib.bindings import LazyGithubBindings
+from lazy_github.lib.constants import private_string
+from lazy_github.lib.github.repositories import list_repos_for_user
+from lazy_github.lib.github.users import get_full_user_by_username
+from lazy_github.lib.logging import lg
+from lazy_github.models.github import FullUser, Repository
+from lazy_github.ui.widgets.common import LazyGithubFooter, _VimLikeDataTable
+
+
+def _format_field(label: str, value: str | int | None) -> str | None:
+    if value is None or value == "":
+        return None
+    return f"[bold]{label}:[/bold] {value}"
+
+
+class UserReposTable(_VimLikeDataTable):
+    """A vim-friendly DataTable for the user's repositories shown inside the profile modal."""
+
+    DEFAULT_CSS = """
+    UserReposTable {
+        height: auto;
+        max-height: 20;
+        margin-top: 1;
+    }
+    """
+
+
+class UserProfileContainer(Container):
+    DEFAULT_CSS = """
+    UserProfileContainer {
+        align: center top;
+        padding: 1 2;
+        height: auto;
+    }
+
+    UserProfileContainer Label {
+        margin-bottom: 1;
+    }
+    """
+
+    def __init__(self, user: FullUser, repos: list[Repository]) -> None:
+        super().__init__()
+        self.user = user
+        self.repos = repos
+        self.repos_by_full_name: dict[str, Repository] = {r.full_name: r for r in repos}
+        self.repos_table = UserReposTable(id="user_repos_table")
+
+    def compose(self) -> ComposeResult:
+        u = self.user
+        header_name = u.name or u.login
+        profile_link = f'[link="{u.html_url}"]@{u.login}[/link]'
+        kind = (u.type or "User").lower()
+
+        yield Label(Content.from_markup(f"[b]{header_name}[/b] ({profile_link}) — {kind}"))
+        yield Rule()
+
+        if u.bio:
+            yield Markdown(u.bio)
+            yield Rule()
+
+        info_lines = [
+            line
+            for line in (
+                _format_field("Company", u.company),
+                _format_field("Location", u.location),
+                _format_field("Email", u.email),
+                _format_field("Blog", u.blog),
+                _format_field("Twitter", f"@{u.twitter_username}" if u.twitter_username else None),
+            )
+            if line
+        ]
+        if info_lines:
+            for line in info_lines:
+                yield Label(Content.from_markup(line))
+            yield Rule()
+
+        joined = u.created_at.strftime("%Y-%m-%d") if u.created_at else "unknown"
+        yield Label(
+            Content.from_markup(
+                f"[bold]Public repos:[/bold] {u.public_repos}    "
+                f"[bold]Gists:[/bold] {u.public_gists}    "
+                f"[bold]Followers:[/bold] {u.followers}    "
+                f"[bold]Following:[/bold] {u.following}"
+            )
+        )
+        yield Label(Content.from_markup(f"[bold]Joined:[/bold] {joined}"))
+
+        yield Rule()
+        repo_count = len(self.repos)
+        if repo_count == 0:
+            yield Label(Content.from_markup("[bold]Recent repositories[/bold]"))
+            yield Label(Content.from_markup("[dim]No public repositories.[/dim]"))
+        else:
+            heading = (
+                f"[bold]Recent repositories[/bold] "
+                f"[dim](showing {repo_count} of {u.public_repos}, press enter to open)[/dim]"
+            )
+            yield Label(Content.from_markup(heading))
+            yield self.repos_table
+
+    def on_mount(self) -> None:
+        if not self.repos:
+            return
+        table = self.repos_table
+        table.cursor_type = "row"
+        table.add_column("Owner", key="owner")
+        table.add_column("Name", key="name")
+        table.add_column("Private", key="private")
+        table.add_column("Description", key="description")
+        for repo in self.repos:
+            description = repo.description or ""
+            table.add_row(
+                repo.owner.login,
+                repo.name,
+                private_string(repo.private),
+                description,
+                key=repo.full_name,
+            )
+
+    def get_selected_repo(self) -> Repository | None:
+        if not self.repos:
+            return None
+        try:
+            owner = self.repos_table.get_cell_at(Coordinate(self.repos_table.cursor_row, 0))
+            name = self.repos_table.get_cell_at(Coordinate(self.repos_table.cursor_row, 1))
+        except Exception:
+            return None
+        return self.repos_by_full_name.get(f"{owner}/{name}")
+
+
+class UserProfileModal(ModalScreen[Repository | None]):
+    DEFAULT_CSS = """
+    UserProfileModal {
+        align: center middle;
+        content-align: center middle;
+    }
+
+    UserProfileModal > ScrollableContainer {
+        width: 90;
+        max-height: 90%;
+        border: thick $background 80%;
+        background: $surface-lighten-1;
+    }
+    """
+
+    BINDINGS = [LazyGithubBindings.CLOSE_DIALOG]
+
+    def __init__(self, user: FullUser, repos: list[Repository]) -> None:
+        super().__init__()
+        self.user = user
+        self.repos = repos
+
+    def compose(self) -> ComposeResult:
+        with ScrollableContainer():
+            yield UserProfileContainer(self.user, self.repos)
+        yield LazyGithubFooter()
+
+    @property
+    def profile_container(self) -> UserProfileContainer:
+        return self.query_one(UserProfileContainer)
+
+    @on(_VimLikeDataTable.RowSelected, "#user_repos_table")
+    async def repo_selected(self) -> None:
+        repo = self.profile_container.get_selected_repo()
+        if repo is not None:
+            self.dismiss(repo)
+
+    async def action_close(self) -> None:
+        self.dismiss(None)
+
+
+async def open_user_profile(app, username: str) -> Repository | None:
+    """Fetch the user's profile and recent repos, push the modal, and return the selected repo (if any)."""
+    try:
+        user, repos = await asyncio.gather(
+            get_full_user_by_username(username),
+            list_repos_for_user(username),
+        )
+    except Exception:
+        lg.exception("Error fetching user profile")
+        app.notify(f"Failed to load profile for @{username}", severity="error")
+        return None
+
+    if user is None:
+        app.notify(f"Could not find user @{username}", severity="error")
+        return None
+
+    return await app.push_screen_wait(UserProfileModal(user, repos))

--- a/lazy_github/ui/widgets/conversations.py
+++ b/lazy_github/ui/widgets/conversations.py
@@ -6,6 +6,7 @@ from textual.widgets import Collapsible, Label, ListItem, ListView, Markdown, St
 
 from lazy_github.lib.bindings import LazyGithubBindings
 from lazy_github.lib.github.pull_requests import ReviewCommentNode
+from lazy_github.lib.github.references import expand_issue_references
 from lazy_github.lib.messages import NewCommentCreated
 from lazy_github.models.github import (
     FullPullRequest,
@@ -111,7 +112,7 @@ class IssueCommentContainer(Container, can_focus=True):
     def compose(self) -> ComposeResult:
         comment_time = self.comment.created_at.strftime("%c")
         author = self.comment.user.login if self.comment.user else "Unknown"
-        yield Markdown(self.comment.body, open_links=False)
+        yield Markdown(expand_issue_references(self.comment.body, self.issue.repo), open_links=False)
         yield Label(f"{author} • {comment_time}", classes="comment-author")
 
     @work
@@ -191,7 +192,7 @@ class ReviewContainer(Container):
         if self.review.body or self.review.comments:
             with Collapsible(title=review_summary, collapsed=self.review.state == ReviewState.DISMISSED):
                 if self.review.body:
-                    yield Markdown(self.review.body, open_links=False)
+                    yield Markdown(expand_issue_references(self.review.body, self.pr.repo), open_links=False)
 
                 for comment in self.review.comments:
                     if comment_node := self.hierarchy.get(comment.id):

--- a/lazy_github/ui/widgets/conversations.py
+++ b/lazy_github/ui/widgets/conversations.py
@@ -6,7 +6,7 @@ from textual.widgets import Collapsible, Label, ListItem, ListView, Markdown, St
 
 from lazy_github.lib.bindings import LazyGithubBindings
 from lazy_github.lib.github.pull_requests import ReviewCommentNode
-from lazy_github.lib.github.references import expand_issue_references
+from lazy_github.lib.github.references import expand_github_references
 from lazy_github.lib.messages import NewCommentCreated
 from lazy_github.models.github import (
     FullPullRequest,
@@ -112,7 +112,7 @@ class IssueCommentContainer(Container, can_focus=True):
     def compose(self) -> ComposeResult:
         comment_time = self.comment.created_at.strftime("%c")
         author = self.comment.user.login if self.comment.user else "Unknown"
-        yield Markdown(expand_issue_references(self.comment.body, self.issue.repo), open_links=False)
+        yield Markdown(expand_github_references(self.comment.body, self.issue.repo), open_links=False)
         yield Label(f"{author} • {comment_time}", classes="comment-author")
 
     @work
@@ -192,7 +192,7 @@ class ReviewContainer(Container):
         if self.review.body or self.review.comments:
             with Collapsible(title=review_summary, collapsed=self.review.state == ReviewState.DISMISSED):
                 if self.review.body:
-                    yield Markdown(expand_issue_references(self.review.body, self.pr.repo), open_links=False)
+                    yield Markdown(expand_github_references(self.review.body, self.pr.repo), open_links=False)
 
                 for comment in self.review.comments:
                     if comment_node := self.hierarchy.get(comment.id):

--- a/lazy_github/ui/widgets/conversations.py
+++ b/lazy_github/ui/widgets/conversations.py
@@ -111,7 +111,7 @@ class IssueCommentContainer(Container, can_focus=True):
     def compose(self) -> ComposeResult:
         comment_time = self.comment.created_at.strftime("%c")
         author = self.comment.user.login if self.comment.user else "Unknown"
-        yield Markdown(self.comment.body)
+        yield Markdown(self.comment.body, open_links=False)
         yield Label(f"{author} • {comment_time}", classes="comment-author")
 
     @work
@@ -191,7 +191,7 @@ class ReviewContainer(Container):
         if self.review.body or self.review.comments:
             with Collapsible(title=review_summary, collapsed=self.review.state == ReviewState.DISMISSED):
                 if self.review.body:
-                    yield Markdown(self.review.body)
+                    yield Markdown(self.review.body, open_links=False)
 
                 for comment in self.review.comments:
                     if comment_node := self.hierarchy.get(comment.id):

--- a/lazy_github/ui/widgets/issues.py
+++ b/lazy_github/ui/widgets/issues.py
@@ -11,7 +11,7 @@ from textual.widgets.data_table import CellDoesNotExist
 from lazy_github.lib.bindings import LazyGithubBindings
 from lazy_github.lib.context import LazyGithubContext
 from lazy_github.lib.github.issues import get_comments, list_issues
-from lazy_github.lib.github.references import expand_issue_references
+from lazy_github.lib.github.references import expand_github_references
 from lazy_github.lib.logging import lg
 from lazy_github.lib.messages import IssuesAndPullRequestsFetched, IssueSelected, NewCommentCreated, RepoSelected
 from lazy_github.models.github import Issue, IssueState, PartialPullRequest, Repository
@@ -172,7 +172,7 @@ class IssueOverviewTabPane(TabPane):
             yield Label(Content.from_markup(f"{issue_status} [b]{self.issue.title}[b] {issue_link} by {user_link}"))
 
             yield Rule()
-            yield Markdown(expand_issue_references(self.issue.body, self.issue.repo), open_links=False)
+            yield Markdown(expand_github_references(self.issue.body, self.issue.repo), open_links=False)
 
     def action_edit_issue(self) -> None:
         self.app.push_screen(EditIssueModal(self.issue))

--- a/lazy_github/ui/widgets/issues.py
+++ b/lazy_github/ui/widgets/issues.py
@@ -159,8 +159,8 @@ class IssueOverviewTabPane(TabPane):
         self.issue = issue
 
     def compose(self) -> ComposeResult:
-        issue_link = f'[link="{self.issue.html_url}"](#{self.issue.number})[/link]'
-        user_link = f'[link="{self.issue.user.html_url}"]{self.issue.user.login}[/link]'
+        issue_link = f"[@click=screen.open_gh_link('{self.issue.html_url}')](#{self.issue.number})[/]"
+        user_link = f"[@click=screen.open_gh_link('{self.issue.user.html_url}')]{self.issue.user.login}[/]"
 
         if self.issue.state == IssueState.OPEN:
             issue_status = "[greenyellow]Open[/]"
@@ -171,7 +171,7 @@ class IssueOverviewTabPane(TabPane):
             yield Label(Content.from_markup(f"{issue_status} [b]{self.issue.title}[b] {issue_link} by {user_link}"))
 
             yield Rule()
-            yield Markdown(self.issue.body)
+            yield Markdown(self.issue.body, open_links=False)
 
     def action_edit_issue(self) -> None:
         self.app.push_screen(EditIssueModal(self.issue))

--- a/lazy_github/ui/widgets/issues.py
+++ b/lazy_github/ui/widgets/issues.py
@@ -12,11 +12,12 @@ from lazy_github.lib.bindings import LazyGithubBindings
 from lazy_github.lib.context import LazyGithubContext
 from lazy_github.lib.github.issues import get_comments, list_issues
 from lazy_github.lib.logging import lg
-from lazy_github.lib.messages import IssuesAndPullRequestsFetched, IssueSelected, NewCommentCreated
+from lazy_github.lib.messages import IssuesAndPullRequestsFetched, IssueSelected, NewCommentCreated, RepoSelected
 from lazy_github.models.github import Issue, IssueState, PartialPullRequest, Repository
 from lazy_github.ui.screens.edit_issue import EditIssueModal
 from lazy_github.ui.screens.lookup_issue import LookupIssueModal
 from lazy_github.ui.screens.new_comment import NewCommentModal
+from lazy_github.ui.screens.user_profile import open_user_profile
 from lazy_github.ui.widgets.common import LazilyLoadedDataTable, LazyGithubContainer, TableRow
 from lazy_github.ui.widgets.conversations import IssueCommentContainer
 
@@ -26,7 +27,11 @@ def issue_to_cell(issue: Issue) -> TableRow:
 
 
 class IssuesContainer(LazyGithubContainer):
-    BINDINGS = [LazyGithubBindings.LOOKUP_ISSUE, LazyGithubBindings.EDIT_ISSUE]
+    BINDINGS = [
+        LazyGithubBindings.LOOKUP_ISSUE,
+        LazyGithubBindings.EDIT_ISSUE,
+        LazyGithubBindings.VIEW_USER_PROFILE,
+    ]
 
     issues: Dict[int, Issue] = {}
     status_column_index = -1
@@ -113,6 +118,16 @@ class IssuesContainer(LazyGithubContainer):
 
     async def action_edit_issue(self) -> None:
         self.trigger_edit_issue_flow()
+
+    @work
+    async def action_view_user_profile(self) -> None:
+        try:
+            issue = await self.get_selected_issue()
+        except CellDoesNotExist:
+            self.notify("No issue currently selected", severity="error")
+            return
+        if selected_repo := await open_user_profile(self.app, issue.user.login):
+            self.post_message(RepoSelected(selected_repo))
 
     @work
     async def action_lookup_issue(self) -> None:

--- a/lazy_github/ui/widgets/issues.py
+++ b/lazy_github/ui/widgets/issues.py
@@ -11,6 +11,7 @@ from textual.widgets.data_table import CellDoesNotExist
 from lazy_github.lib.bindings import LazyGithubBindings
 from lazy_github.lib.context import LazyGithubContext
 from lazy_github.lib.github.issues import get_comments, list_issues
+from lazy_github.lib.github.references import expand_issue_references
 from lazy_github.lib.logging import lg
 from lazy_github.lib.messages import IssuesAndPullRequestsFetched, IssueSelected, NewCommentCreated, RepoSelected
 from lazy_github.models.github import Issue, IssueState, PartialPullRequest, Repository
@@ -171,7 +172,7 @@ class IssueOverviewTabPane(TabPane):
             yield Label(Content.from_markup(f"{issue_status} [b]{self.issue.title}[b] {issue_link} by {user_link}"))
 
             yield Rule()
-            yield Markdown(self.issue.body, open_links=False)
+            yield Markdown(expand_issue_references(self.issue.body, self.issue.repo), open_links=False)
 
     def action_edit_issue(self) -> None:
         self.app.push_screen(EditIssueModal(self.issue))

--- a/lazy_github/ui/widgets/link_hints.py
+++ b/lazy_github/ui/widgets/link_hints.py
@@ -223,8 +223,13 @@ class LinkHintScreen(ModalScreen[_LinkHit | None]):
             self.dismiss(None)
 
 
-async def follow_link(screen: "LazyGithubMainScreen") -> None:
-    """Entry point: collect links on the main screen, show hints, dispatch the pick."""
+async def follow_link(screen: "LazyGithubMainScreen", *, external: bool = False) -> None:
+    """Entry point: collect links on the main screen, show hints, dispatch the pick.
+
+    With `external=True`, picked URLs open in the system browser instead of
+    being routed through the in-app resolver. Non-URL action hits still run
+    in-app since "open externally" has no meaning for them.
+    """
     hits = collect_link_hits(screen)
     if not hits:
         screen.notify("No links visible", severity="information")
@@ -234,6 +239,10 @@ async def follow_link(screen: "LazyGithubMainScreen") -> None:
     if pick is None:
         return
     if pick.href is not None:
-        screen.action_open_gh_link(pick.href)
+        if external:
+            screen.app.open_url(pick.href)
+            screen.notify(f"Opening {pick.href} externally")
+        else:
+            screen.action_open_gh_link(pick.href)
     elif pick.action is not None:
         await screen.run_action(pick.action)  # pragma: no cover - no current callers

--- a/lazy_github/ui/widgets/link_hints.py
+++ b/lazy_github/ui/widgets/link_hints.py
@@ -1,0 +1,239 @@
+"""Hint-mode (Vimium-style) link follower for the main screen.
+
+Press the bound key, see one-or-two-letter labels overlaid on every visible
+link, type the label to activate. Works for both `[@click=...]` action markup
+in Labels/Static widgets and standard Markdown links.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from textual import events
+from textual.app import ComposeResult
+from textual.content import Content
+from textual.geometry import Offset
+from textual.screen import ModalScreen
+from textual.widget import Widget
+from textual.widgets import Static
+
+if TYPE_CHECKING:
+    from lazy_github.ui.screens.primary import LazyGithubMainScreen
+
+HINT_ALPHABET = "asdfghjklqwertyuiopzxcvbnm"
+
+_MARKDOWN_LINK_ACTION_RE = re.compile(r"^link\((['\"])(?P<href>.*)\1\)$")
+_OPEN_GH_LINK_ACTION_RE = re.compile(r"^screen\.open_gh_link\((['\"])(?P<href>.*)\1\)$")
+
+
+@dataclass
+class _LinkHit:
+    """A clickable thing we found on screen, with the absolute position to anchor a hint to."""
+
+    x: int
+    y: int
+    label_text: str
+    action: str | None = None
+    href: str | None = None
+
+
+def _hint_codes(count: int, alphabet: str = HINT_ALPHABET) -> list[str]:
+    """Generate `count` short, distinct hint codes (a, b, ..., aa, ab, ...)."""
+    if count <= 0:
+        return []
+    if count <= len(alphabet):
+        return list(alphabet[:count])
+    # Two-char codes; should be enough for any realistic page.
+    codes = list(alphabet)
+    for first in alphabet:
+        for second in alphabet:
+            codes.append(first + second)
+            if len(codes) >= count:
+                return codes[:count]
+    return codes[:count]
+
+
+def _content_from_widget(widget: Widget) -> Content | None:
+    """Pull the Content that a widget renders, if any."""
+    visual = getattr(widget, "visual", None)
+    if isinstance(visual, Content):
+        return visual
+    renderable = getattr(widget, "renderable", None)
+    if isinstance(renderable, Content):
+        return renderable
+    internal = getattr(widget, "_content", None)
+    if isinstance(internal, Content):
+        return internal
+    return None
+
+
+def _extract_link_text(plain: str, span_start: int, span_end: int) -> str:
+    text = plain[span_start:span_end].strip()
+    return text or plain[max(0, span_start - 10) : span_end + 10].strip()
+
+
+def _action_from_span_style(style: object) -> str | None:
+    """Pull the click action string out of a span's style.
+
+    Handcrafted markup stores it as a literal `@click=action` string;
+    the Markdown widget stores it as a `Style` instance with `meta={"@click": action}`.
+    """
+    if isinstance(style, str):
+        if style.startswith("@click="):
+            return style[len("@click=") :]
+        return None
+    meta = getattr(style, "meta", None)
+    if isinstance(meta, dict):
+        action = meta.get("@click")
+        if isinstance(action, str):
+            return action
+    return None
+
+
+def _classify_action(action: str) -> tuple[str | None, str | None]:
+    """Map a click action string to (action_to_run, href_to_open)."""
+    if md := _MARKDOWN_LINK_ACTION_RE.match(action):
+        return None, md.group("href")
+    if gh := _OPEN_GH_LINK_ACTION_RE.match(action):
+        return None, gh.group("href")
+    return action, None
+
+
+def collect_link_hits(screen_widget: Widget) -> list[_LinkHit]:
+    """Walk the widget tree under `screen_widget` and return one hit per clickable link."""
+    hits: list[_LinkHit] = []
+    seen_positions: set[tuple[int, int]] = set()
+    for node in screen_widget.walk_children(with_self=False):
+        if not isinstance(node, Widget):
+            continue
+        if not node.display or not node.visible:
+            continue
+        region = node.region
+        if not region or region.width <= 0 or region.height <= 0:
+            continue
+
+        content = _content_from_widget(node)
+        if content is None or not content.spans:
+            continue
+
+        # Wrap to the widget's content width so span offsets become per-line.
+        content_region = node.content_region
+        wrap_width = content_region.width if content_region.width > 0 else region.width
+        if wrap_width <= 0:
+            continue
+
+        try:
+            wrapped_lines = content.wrap(wrap_width)
+        except Exception:
+            continue
+
+        origin_x = content_region.x if content_region.width > 0 else region.x
+        origin_y = content_region.y if content_region.height > 0 else region.y
+        max_y = region.y + region.height
+
+        for line_index, line in enumerate(wrapped_lines):
+            line_y = origin_y + line_index
+            if line_y >= max_y:
+                break
+            for span in line.spans:
+                action_str = _action_from_span_style(span.style)
+                if action_str is None:
+                    continue
+                action, href = _classify_action(action_str)
+                prefix = line.plain[: span.start]
+                col = Content(prefix).cell_length
+                x = origin_x + col
+                if x >= region.x + region.width:
+                    continue
+                key = (x, line_y)
+                if key in seen_positions:
+                    continue
+                seen_positions.add(key)
+                hits.append(
+                    _LinkHit(
+                        x=x,
+                        y=line_y,
+                        label_text=_extract_link_text(line.plain, span.start, span.end),
+                        action=action,
+                        href=href,
+                    )
+                )
+    return hits
+
+
+class LinkHintScreen(ModalScreen[_LinkHit | None]):
+    """Transparent overlay that shows hint markers and captures the next keystrokes."""
+
+    DEFAULT_CSS = """
+    LinkHintScreen {
+        background: transparent;
+        layers: hints;
+    }
+
+    LinkHintScreen .link-hint {
+        layer: hints;
+        background: $warning;
+        color: black;
+        text-style: bold;
+        height: 1;
+        padding: 0;
+        margin: 0;
+        border: none;
+    }
+    """
+
+    def __init__(self, hits: list[_LinkHit]) -> None:
+        super().__init__()
+        codes = _hint_codes(len(hits))
+        # Pad all codes to a uniform width so single-letter hints don't get
+        # stretched by layout and so two-letter hints aren't truncated.
+        self._code_width = max((len(c) for c in codes), default=1)
+        self._by_code: dict[str, _LinkHit] = {code: hit for code, hit in zip(codes, hits)}
+        self._buffer = ""
+
+    def compose(self) -> ComposeResult:
+        for code, hit in self._by_code.items():
+            hint = Static(code.ljust(self._code_width), classes="link-hint")
+            hint.styles.width = self._code_width
+            hint.absolute_offset = Offset(hit.x, hit.y)
+            yield hint
+
+    def on_key(self, event: events.Key) -> None:
+        if event.key == "escape":
+            event.stop()
+            self.dismiss(None)
+            return
+
+        char = event.character
+        if not char or char not in HINT_ALPHABET:
+            return
+
+        event.stop()
+        self._buffer += char
+
+        # Exact match → fire.
+        if hit := self._by_code.get(self._buffer):
+            self.dismiss(hit)
+            return
+
+        # No prefix matches anything → bail.
+        if not any(code.startswith(self._buffer) for code in self._by_code):
+            self.dismiss(None)
+
+
+async def follow_link(screen: "LazyGithubMainScreen") -> None:
+    """Entry point: collect links on the main screen, show hints, dispatch the pick."""
+    hits = collect_link_hits(screen)
+    if not hits:
+        screen.notify("No links visible", severity="information")
+        return
+
+    pick = await screen.app.push_screen_wait(LinkHintScreen(hits))
+    if pick is None:
+        return
+    if pick.href is not None:
+        screen.action_open_gh_link(pick.href)
+    elif pick.action is not None:
+        await screen.run_action(pick.action)  # pragma: no cover - no current callers

--- a/lazy_github/ui/widgets/pull_requests.py
+++ b/lazy_github/ui/widgets/pull_requests.py
@@ -31,6 +31,7 @@ from lazy_github.lib.github.pull_requests import (
     reconstruct_review_conversation_hierarchy,
 )
 from lazy_github.lib.github.reactions import add_reaction_on_issue, list_reactions_on_comment, list_reactions_on_issue
+from lazy_github.lib.github.references import expand_issue_references
 from lazy_github.lib.logging import lg
 from lazy_github.lib.messages import (
     CommentReactionsLoaded,
@@ -388,7 +389,7 @@ class PrOverviewTabPane(TabPane):
                 yield ListView(id="reviews_list")
 
             yield Rule()
-            yield Markdown(self.pr.body, open_links=False)
+            yield Markdown(expand_issue_references(self.pr.body, self.pr.repo), open_links=False)
 
     @work
     async def add_reviews(self, reviews: list[Review]) -> None:

--- a/lazy_github/ui/widgets/pull_requests.py
+++ b/lazy_github/ui/widgets/pull_requests.py
@@ -253,14 +253,14 @@ class PrOverviewTabPane(TabPane):
         status_summary = status.state.to_display()
         label = f"{status_summary} {status.context} - {status.description}"
         if status.target_url:
-            label = f'[link="{status.target_url}"]{label}[/link]'
+            label = f"[@click=screen.open_gh_link('{status.target_url}')]{label}[/]"
         return label
 
     def _check_run_to_label(self, check_run: CheckRun) -> str:
         status_summary = check_run.to_check_status_state().to_display()
         label = f"{status_summary} {check_run.name}"
         if check_run.html_url:
-            label = f'[link="{check_run.html_url}"]{label}[/link]'
+            label = f"[@click=screen.open_gh_link('{check_run.html_url}')]{label}[/]"
         return label
 
     def _overall_pr_status(self, combined_status: CombinedCheckStatus, check_runs: CheckRunList) -> str:
@@ -339,8 +339,8 @@ class PrOverviewTabPane(TabPane):
             self.post_message(PullRequestSelected(updated_pr))
 
     def compose(self) -> ComposeResult:
-        pr_link = f'[link="{self.pr.html_url}"](#{self.pr.number})[/link]'
-        user_link = f'[link="{self.pr.user.html_url}"]{self.pr.user.login}[/link]'
+        pr_link = f"[@click=screen.open_gh_link('{self.pr.html_url}')](#{self.pr.number})[/]"
+        user_link = f"[@click=screen.open_gh_link('{self.pr.user.html_url}')]{self.pr.user.login}[/]"
         merge_from = None
         if self.pr.head:
             merge_from = f"[bold]{self.pr.head.user.login}:{self.pr.head.ref}[/bold]"
@@ -388,7 +388,7 @@ class PrOverviewTabPane(TabPane):
                 yield ListView(id="reviews_list")
 
             yield Rule()
-            yield Markdown(self.pr.body)
+            yield Markdown(self.pr.body, open_links=False)
 
     @work
     async def add_reviews(self, reviews: list[Review]) -> None:

--- a/lazy_github/ui/widgets/pull_requests.py
+++ b/lazy_github/ui/widgets/pull_requests.py
@@ -31,7 +31,7 @@ from lazy_github.lib.github.pull_requests import (
     reconstruct_review_conversation_hierarchy,
 )
 from lazy_github.lib.github.reactions import add_reaction_on_issue, list_reactions_on_comment, list_reactions_on_issue
-from lazy_github.lib.github.references import expand_issue_references
+from lazy_github.lib.github.references import expand_github_references
 from lazy_github.lib.logging import lg
 from lazy_github.lib.messages import (
     CommentReactionsLoaded,
@@ -389,7 +389,7 @@ class PrOverviewTabPane(TabPane):
                 yield ListView(id="reviews_list")
 
             yield Rule()
-            yield Markdown(expand_issue_references(self.pr.body, self.pr.repo), open_links=False)
+            yield Markdown(expand_github_references(self.pr.body, self.pr.repo), open_links=False)
 
     @work
     async def add_reviews(self, reviews: list[Review]) -> None:

--- a/lazy_github/ui/widgets/pull_requests.py
+++ b/lazy_github/ui/widgets/pull_requests.py
@@ -36,6 +36,7 @@ from lazy_github.lib.messages import (
     CommentReactionsLoaded,
     IssuesAndPullRequestsFetched,
     PullRequestSelected,
+    RepoSelected,
     ReviewsAndCommentsLoaded,
 )
 from lazy_github.models.github import (
@@ -59,6 +60,7 @@ from lazy_github.ui.screens.create_or_edit_pull_request import (
 )
 from lazy_github.ui.screens.lookup_pull_request import LookupPullRequestModal
 from lazy_github.ui.screens.new_comment import NewCommentModal
+from lazy_github.ui.screens.user_profile import open_user_profile
 from lazy_github.ui.widgets.common import (
     LazilyLoadedDataTable,
     LazyGithubContainer,
@@ -77,7 +79,11 @@ class PullRequestsContainer(LazyGithubContainer):
     This container includes the primary datatable for viewing pull requests on the UI.
     """
 
-    BINDINGS = [LazyGithubBindings.LOOKUP_PULL_REQUEST, LazyGithubBindings.EDIT_PULL_REQUEST]
+    BINDINGS = [
+        LazyGithubBindings.LOOKUP_PULL_REQUEST,
+        LazyGithubBindings.EDIT_PULL_REQUEST,
+        LazyGithubBindings.VIEW_USER_PROFILE,
+    ]
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
@@ -112,6 +118,16 @@ class PullRequestsContainer(LazyGithubContainer):
         elif updated_pr := await self.app.push_screen_wait(CreateOrEditPullRequestModal(full_pr)):
             self.searchable_table.add_item(updated_pr)
             self.post_message(PullRequestSelected(updated_pr))
+
+    @work
+    async def action_view_user_profile(self) -> None:
+        try:
+            pr = await self.get_selected_pr()
+        except Exception:
+            self.notify("No pull request currently selected", severity="error")
+            return
+        if selected_repo := await open_user_profile(self.app, pr.user.login):
+            self.post_message(RepoSelected(selected_repo))
 
     @work
     async def action_lookup_pull_request(self) -> None:

--- a/lazy_github/ui/widgets/repositories.py
+++ b/lazy_github/ui/widgets/repositories.py
@@ -15,6 +15,7 @@ from lazy_github.lib.logging import lg
 from lazy_github.lib.messages import RepoSelected
 from lazy_github.models.github import Repository
 from lazy_github.ui.screens.lookup_repository import LookupRepositoryModal
+from lazy_github.ui.screens.user_profile import open_user_profile
 from lazy_github.ui.widgets.common import LazyGithubContainer, SearchableDataTable, TableRow
 
 
@@ -28,6 +29,7 @@ class ReposContainer(LazyGithubContainer):
     BINDINGS = [
         LazyGithubBindings.TOGGLE_FAVORITE_REPO,
         LazyGithubBindings.LOOKUP_REPOSITORY,
+        LazyGithubBindings.VIEW_USER_PROFILE,
     ]
 
     def __init__(self, *args, **kwargs) -> None:
@@ -83,6 +85,18 @@ class ReposContainer(LazyGithubContainer):
         repo_name = self.table.get_cell_at(Coordinate(current_row, self.name_column_index))
         full_name = f"{owner}/{repo_name}"
         return self.searchable_table.items[full_name]
+
+    @work
+    async def action_view_user_profile(self) -> None:
+        try:
+            repo = await self.get_selected_repo()
+        except Exception:
+            self.notify("No repository currently selected", severity="error")
+            return
+        if selected_repo := await open_user_profile(self.app, repo.owner.login):
+            if not self.searchable_table.item_in_table(selected_repo):
+                self.searchable_table.add_item(selected_repo)
+            self.post_message(RepoSelected(selected_repo))
 
     @work
     async def action_lookup_repository(self) -> None:

--- a/lazy_github/ui/widgets/repository_details.py
+++ b/lazy_github/ui/widgets/repository_details.py
@@ -1,0 +1,57 @@
+from textual import work
+from textual.app import ComposeResult
+from textual.containers import ScrollableContainer
+from textual.content import Content
+from textual.widgets import Label, Markdown, Rule, TabPane
+
+from lazy_github.lib.github.repositories import get_repo_readme
+from lazy_github.models.github import Repository
+
+
+class RepoOverviewTabPane(TabPane):
+    DEFAULT_CSS = """
+    RepoOverviewTabPane {
+        overflow-y: auto;
+    }
+    """
+
+    def __init__(self, repo: Repository) -> None:
+        super().__init__("Repo Overview", id="repo_overview_pane")
+        self.repo = repo
+
+    def compose(self) -> ComposeResult:
+        repo_url = f"https://github.com/{self.repo.full_name}"
+        owner_url = self.repo.owner.html_url
+
+        title_link = f"[@click=screen.open_gh_link('{repo_url}')]{self.repo.full_name}[/]"
+        owner_link = f"[@click=screen.open_gh_link('{owner_url}')]{self.repo.owner.login}[/]"
+
+        flags: list[str] = []
+        if self.repo.private:
+            flags.append("[red]Private[/]")
+        else:
+            flags.append("[greenyellow]Public[/]")
+        if self.repo.archived:
+            flags.append("[orchid]Archived[/]")
+
+        with ScrollableContainer():
+            yield Label(Content.from_markup(f"[b]{title_link}[/] • {' • '.join(flags)}"))
+            yield Label(Content.from_markup(f"Owned by {owner_link}"))
+            if self.repo.default_branch:
+                yield Label(Content.from_markup(f"Default branch: [bold]{self.repo.default_branch}[/]"))
+            if self.repo.description:
+                yield Label(Content.from_markup(f"\n{self.repo.description}"))
+            yield Rule()
+            yield Markdown(id="repo_readme", open_links=False)
+
+    def on_mount(self) -> None:
+        self.load_readme()
+
+    @work
+    async def load_readme(self) -> None:
+        readme = await get_repo_readme(self.repo)
+        markdown = self.query_one("#repo_readme", Markdown)
+        if readme:
+            await markdown.update(readme)
+        else:
+            await markdown.update("*No README found.*")


### PR DESCRIPTION
# What's changing?

This PR adds a few new UI features:

- A new details pane for the currently selected repo, showing you the repo's README contents.
- The ability to quick select links in descriptions, comments, etc and jump to their location within lazy-github.
- A new modal screen for showing details about a user (such as a PR or issue author)